### PR TITLE
Change DBD::Pg to DBD::Oracle

### DIFF
--- a/lib/DBD/Oracle.pm
+++ b/lib/DBD/Oracle.pm
@@ -2821,7 +2821,7 @@ to change just the type and will be overwriting the value later.
 
 The C<\%attr> hash is used to indicate the data type of the placeholder.
 The default value is "varchar". If you need something else, you must
-use one of the values provided by DBI or by DBD::Pg. To use a SQL value,
+use one of the values provided by DBI or by DBD::Oracle. To use a SQL value,
 modify your "use DBI" statement at the top of your script as follows:
 
   use DBI qw(:sql_types);
@@ -2834,7 +2834,7 @@ encounter are:
 
 To use Oracle SQL data types, import the list of values like this:
 
-  use DBD::Pg qw(:ora_types);
+  use DBD::Oracle qw(:ora_types);
 
 You can then set the data types by setting the value of the C<ora_type>
 key in the hash passed to L</bind_param>.
@@ -2854,7 +2854,7 @@ doing the next execute.
 Examples:
 
   use DBI qw(:sql_types);
-  use DBD::Pg qw(:ora_types);
+  use DBD::Oracle qw(:ora_types);
 
   $SQL = "SELECT id FROM ptable WHERE size > ? AND title = ?";
   $sth = $dbh->prepare($SQL);


### PR DESCRIPTION
Some documentation was "strongly inspired" by DBD::Pg documentation. So strongly, that we forgot to change 'Pg'
to 'Oracle' in a few places. :-)

Caught by Martin J. Evans.