### PR TITLE
Fix printf format-string errors on 64-bit Linux

### DIFF
--- a/oci8.c
+++ b/oci8.c
@@ -1844,7 +1844,8 @@ ora_blob_read_mb_piece(SV *sth, imp_sth_t *imp_sth, imp_fbh_t *fbh,
             DBIc_LOGPIO(imp_sth),
             "	blob_read field %d, ftype %d, offset %ld, len %lu, "
             "destoffset %ld, retlen %lu\n",
-			fbh->field_num+1, ftype, offset, len, destoffset, ul_t(amtp));
+			fbh->field_num+1, ftype, offset, (unsigned long) len,
+                        destoffset, ul_t(amtp));
 
 	SvCUR_set(dest_sv, byte_destoffset+amtp);
 	*SvEND(dest_sv) = '\0'; /* consistent with perl sv_setpvn etc	*/

--- a/ocitrace.h
+++ b/ocitrace.h
@@ -71,8 +71,8 @@
     stat =OCISessionPoolCreate(envhp,errhp,ph,pn,pnl,dbn,dbl,sn,sm,si,un,unl,pw,pwl,OCI_DEFAULT);\
     (DBD_OCI_TRACEON(impdbh))                                          \
     ? PerlIO_printf(DBD_OCI_TRACEFP(impdbh),                           \
-					 "%sOCISessionPoolCreate(envhp=%p,ph=%p,pn=%p,pnl=%p,min=%d,max=%d,incr=%d, un=%s,unl=%d,pw=%s,pwl=%d)=%s\n",\
-					 OciTp, envhp,ph,pn,pnl,sn,sm,si,un,unl,pw,pwl,oci_status_name(stat)),stat \
+					 "%sOCISessionPoolCreate(envhp=%p,ph=%p,pn=%p,pnl=%p,min=%d,max=%d,incr=%d, un=%s,unl=%d,pw=%s,pwl=%lu)=%s\n",\
+					 OciTp, envhp,ph,pn,pnl,sn,sm,si,un,(unsigned long)unl,pw,(unsigned long)pwl,oci_status_name(stat)),stat \
 	: stat
 
 #if defined(ORA_OCI_102)


### PR DESCRIPTION
The commits here fix errors in format strings that I noticed when @abraxxa reported test failures in t/38taf.t under Perl 5.22.1-RC4.

I don't have Oracle to run tests against, so **please do not apply this patch untested**. However, I'm fairly sure that the current code is incorrect; and these changes, although not even compiled, seem likely to fix the problems I could see in @abraxxa's reported compiler output.

Thanks.
