### PR TITLE
Search for Oracle Instant Client .mk file location when compiling for…

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1153,7 +1153,8 @@ sub find_mkfile {
     	'rdbms/demo/demo_xe.mk',
         'rdbms/demo/demo_rdbms32.mk',
         'rdbms/demo/demo_rdbms.mk',
-        'rdbms/lib/ins_rdbms.mk' #Oracle 11 full client
+        'rdbms/lib/ins_rdbms.mk', #Oracle 11 full client
+        'sdk/demo/demo.mk' #OIC .mk location
     );
     my @mk_oci64 = (
 	'rdbms/demo/demo_xe.mk',


### PR DESCRIPTION
… 32 bit. This was talked about in issue #47 (5) and appears to have been fixed before but only for 64 bit builds.