### PR TITLE
Have ora_libdir check $ORACLE_HOME/lib/64 when it exists

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1121,7 +1121,9 @@ sub perl_is_64bit {
 sub ora_libdir {
     my $libdir = 'lib' ;
     if ( $client_version >= 9 ) {
-	$libdir = 'lib32' if ! perl_is_64bit() and -d "$OH/lib32";
+        $libdir = 'lib32' if ! perl_is_64bit() and -d "$OH/lib32";
+        $libdir = 'lib/64' if perl_is_64bit() and -d "$OH/lib/64";
+           # Solaris OIC 12+ from pkg 
     }
     else {
         $libdir = 'lib64' if   perl_is_64bit() and -d "$OH/lib64";


### PR DESCRIPTION
and the build is for 64 bit.

This is the location of 64 bit library files when Oracle Instant Client 12+ is installed from a package on Solaris 11+.

Yes, I know that adding $ORACLE_HOME/lib/64 to LD_LIBRARY_PATH will fix issues with compiling. But when you build with LD_LIBRARY_PATH set you are always forced to set it in your environment from there on out. This simple additional check allows you to compile without LD_LIBRARY_PATH set (on SunOS).