### PR TITLE
Make Makefile.PL more friendly for Linux RPM Instant Client installs

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -979,6 +979,13 @@ sub find_oracle_home {
 	@oh = grep { (glob("$_/../lib*/libclntsh.$so*"))[0] } @path;
 	s:/[^/]/?$:: for @oh;
     }
+    if (!@oh && lc($^O) eq 'linux') { # Try the standard Linux RPM location
+   my @loh = glob("/usr/lib/oracle/*/*/lib/libclntsh.$so*");
+   sort { $a <=> $b } @loh;
+   my $loh = pop(@loh);
+   $loh =~ s/\/libclntsh.*$//g;
+   push(@oh,$loh);
+    }
     print "Found @oh\n" if @oh;
     return $oh[0];
 }
@@ -1690,6 +1697,9 @@ sub get_client_version {
 	}
 	elsif ( "$OH/" =~ m!/10g!) { # scary but handy
 	    $client_version_full = "10.0.0.0";
+	}
+	elsif ( "$OH/" =~ m!/usr/lib/oracle/(\d+\.\d)/!) { # Linux RPM
+	    $client_version_full = "$1.0.0";
 	}
     }
 


### PR DESCRIPTION
These additional checks makes it to where if you installed Instant Client from the RPMs (basic and devel), then Makefile.PL will pick it and the correct (and highest if there are multiple) version without ORACLE_HOME/LD_LIBRARY_PATH set. Setting ORACLE_HOME or LD_LIBRARY_PATH will grab the version from the path.

I'm surprised it wasn't doing this already since I found a couple of other places /usr/*/oracle was referenced for the sake of Linux RPM installs.

I tested against Oracle Linux 12.2/18.3 rpm/zip and Oracle Solaris 11.2/12.2/18.3 zip installs of Instant Client.

We could say this resolves #68.